### PR TITLE
Fix image show view to behave according the show_view_types.md file

### DIFF
--- a/Resources/views/CRUD/show_image.html.twig
+++ b/Resources/views/CRUD/show_image.html.twig
@@ -12,7 +12,11 @@ file that was distributed with this source code.
 {% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
 
 {% block field %}
-    {% if value %}
-        <img src="{% if field_description.options.prefix is defined %}{{ field_description.options.prefix }}{% endif %}{{ value }}" />
-    {% endif %}
+        {% set width = field_description.options.width is defined ? field_description.options.width : 50 %}
+        {% set height = field_description.options.height is defined ? field_description.options.height : 50 %}
+        {% if value %}
+            <img src="{% if field_description.options.prefix is defined %}{{ field_description.options.prefix }}{% endif %}{{ value }}" style="max-width:{{ width }}px; max-height:{{ height }}px;"/>
+        {% else %}
+            <div class="no-image" style="width:{{ width }}px; height:{{ height }}px;"></div>
+        {% endif %}
 {% endblock %}


### PR DESCRIPTION
According to the 'Resources/doc/show_view_types.md` file:

> #### Available options
> 
> ``` php
> protected function configureShowFields(ShowMapper $showMapper)
> {
>     $showMapper
>         ...
>         ->add('picture', 'image', [
>             'prefix' => '/bundles/acme/images/', // Image url prefix, default to null
>             'width' => 75, // Image width, default to 50px,
>             'height' => 75, // Image height, default to 50px,
>         ]);
> }
> ```

But the show template, does not have the `prefix`, the `width` and the `height` options available.
This PR adds these options to the template.